### PR TITLE
fix: replace networkidle with load to avoid timeouts on Cloudflare/chat/pixel sites

### DIFF
--- a/src/extractors/tokens/computed.ts
+++ b/src/extractors/tokens/computed.ts
@@ -49,7 +49,13 @@ export async function extractComputedTokens(url: string, maxPages = 5): Promise<
 
       try {
         const page = await context.newPage();
-        await page.goto(currentUrl, { waitUntil: 'networkidle', timeout: 20000 });
+        await page.goto(currentUrl, { waitUntil: 'load', timeout: 60000 });
+        try {
+          await page.waitForLoadState('networkidle', { timeout: 8000 });
+        } catch {
+          // networkidle is unreliable on sites with chat / bot-protection /
+          // tracking pixels that hold connections open indefinitely.
+        }
 
         // Wait a moment for any JS-rendered content
         await page.waitForTimeout(1500);

--- a/src/extractors/ultra/animations.ts
+++ b/src/extractors/ultra/animations.ts
@@ -69,7 +69,13 @@ export async function captureAnimations(
       (window as any).__claudeui_originalRAF = window.requestAnimationFrame;
     });
 
-    await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    try {
+      await page.waitForLoadState('networkidle', { timeout: 8000 });
+    } catch {
+      // networkidle is unreliable on sites with chat / bot-protection /
+      // tracking pixels that hold connections open indefinitely.
+    }
     await page.waitForTimeout(2000);
 
     // ── Phase 1: Extract CSS keyframes from document.styleSheets ──────────

--- a/src/extractors/ultra/components-dom.ts
+++ b/src/extractors/ultra/components-dom.ts
@@ -24,7 +24,13 @@ export async function detectDOMComponents(url: string): Promise<DOMComponent[]> 
     });
 
     const page = await context.newPage();
-    await page.goto(url, { waitUntil: 'networkidle', timeout: 25000 });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    try {
+      await page.waitForLoadState('networkidle', { timeout: 8000 });
+    } catch {
+      // networkidle is unreliable on sites with chat / bot-protection /
+      // tracking pixels that hold connections open indefinitely.
+    }
     await page.waitForTimeout(1000);
 
     const components: DOMComponent[] = await page.evaluate(() => {

--- a/src/extractors/ultra/interactions.ts
+++ b/src/extractors/ultra/interactions.ts
@@ -59,7 +59,13 @@ export async function captureInteractions(
     });
 
     const page = await context.newPage();
-    await page.goto(url, { waitUntil: 'networkidle', timeout: 25000 });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    try {
+      await page.waitForLoadState('networkidle', { timeout: 8000 });
+    } catch {
+      // Sites with chat widgets, Cloudflare Turnstile, or remarketing pixels
+      // hold connections open indefinitely. Proceed once `load` has fired.
+    }
     await page.waitForTimeout(1500);
 
     for (const { type, selector } of INTERACTIVE_SELECTORS) {

--- a/src/extractors/ultra/layout.ts
+++ b/src/extractors/ultra/layout.ts
@@ -25,7 +25,13 @@ export async function extractLayouts(url: string): Promise<LayoutRecord[]> {
     });
 
     const page = await context.newPage();
-    await page.goto(url, { waitUntil: 'networkidle', timeout: 25000 });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    try {
+      await page.waitForLoadState('networkidle', { timeout: 8000 });
+    } catch {
+      // See note in interactions.ts — networkidle is unreliable on modern
+      // sites. Fall back to `load` so the run continues.
+    }
     await page.waitForTimeout(1000);
 
     const records: LayoutRecord[] = await page.evaluate(() => {

--- a/src/extractors/ultra/pages.ts
+++ b/src/extractors/ultra/pages.ts
@@ -52,7 +52,13 @@ export async function capturePageScreenshots(
 
       try {
         const page = await context.newPage();
-        await page.goto(url, { waitUntil: 'networkidle', timeout: 25000 });
+        await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+        try {
+          await page.waitForLoadState('networkidle', { timeout: 8000 });
+        } catch {
+          // networkidle is unreliable on sites with chat / bot-protection /
+          // tracking pixels that hold connections open indefinitely.
+        }
         await page.waitForTimeout(1500);
 
         // Full-page screenshot

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -16,8 +16,10 @@ export async function captureScreenshot(
     const screenshotsDir = path.join(skillDir, 'screenshots');
     fs.mkdirSync(screenshotsDir, { recursive: true });
 
-    // microlink.io with embed=screenshot.url returns the image bytes directly
-    const apiUrl = `https://api.microlink.io?url=${encodeURIComponent(url)}&screenshot=true&meta=false&embed=screenshot.url&waitFor=2000`;
+    // microlink.io with embed=screenshot.url returns the image bytes directly.
+    // screenshot.fullPage=true captures the entire scrollable page rather than
+    // just the 1280×720 viewport.
+    const apiUrl = `https://api.microlink.io?url=${encodeURIComponent(url)}&screenshot=true&meta=false&embed=screenshot.url&waitFor=2000&screenshot.fullPage=true`;
 
     const res = await fetch(apiUrl, {
       headers: { 'User-Agent': 'skillui/1.0' },


### PR DESCRIPTION
## Problem

`waitUntil: 'networkidle'` requires zero in-flight network connections for 500ms straight. That condition never becomes true on sites that hold connections open indefinitely:

- **Cloudflare Turnstile / Bot Management** challenge widgets (3+ long-poll connections per page)
- Chat widgets — Tawk.to, Intercom, Drift, LiveChat, Zendesk
- Session recording — Hotjar, FullStory, LogRocket
- Remarketing pixels — Google Ads `ga-audiences`, Meta Pixel

That's most of the modern commercial web. On any affected site, the 25–30s timeout fires and ultra extraction silently bails with no useful data.

## Repro

```bash
skillui --url https://gironroofing.com --mode ultra
# → ✗ Ultra extraction  page.goto: Timeout 30000ms exceeded.
# →   Call log: navigating to "https://gironroofing.com/", waiting until "networkidle"
```

I confirmed via Playwright instrumentation that 4 connections were still open 10s after `load` fired on that site (3× `challenges.cloudflare.com/...`, 1× `www.google.com/ads/ga-audiences`).

## Fix

For each of the 6 primary `page.goto` calls in the ultra + computed extractors:

1. Switch `waitUntil: 'networkidle'` → `waitUntil: 'load'` (DOMContentLoaded + initial resources fired).
2. Attempt a **soft** `waitForLoadState('networkidle', { timeout: 8000 })` inside a `try/catch` so well-behaved sites still get the same idle benefit.
3. Bump the goto timeout from 25–30s to 60s for slow networks.

Either way the run continues and produces real data instead of silently bailing.

Also adds `&screenshot.fullPage=true` to the Microlink screenshot URL so `screenshots/homepage.png` captures the full scrollable page rather than just the 1280×720 viewport (which the API defaults to).

## Files touched

- `src/extractors/ultra/animations.ts`
- `src/extractors/ultra/components-dom.ts`
- `src/extractors/ultra/interactions.ts`
- `src/extractors/ultra/layout.ts`
- `src/extractors/ultra/pages.ts`
- `src/extractors/tokens/computed.ts`
- `src/screenshot.ts`

7 files, +46/-8 lines. No public API change.

## Test plan

- [x] Built the patched bundle with `npm run build`
- [x] Verified bundle has 0 primary `networkidle` waits and 6 `load` waits with soft fallbacks
- [x] Smoke-tested against `gironroofing.com` (the Cloudflare-Turnstile-protected repro site) — ultra extraction completes without timing out
- [x] Microlink full-page screenshot captures the entire scrollable page