### PR TITLE
Dismiss cookie/consent overlays before screenshot extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ skillui --url https://linear.app
 
 Uses Playwright to capture scroll screenshots, interaction diffs, animation detection, layout analysis, and DOM component fingerprinting.
 
+Cookie/consent banners (Cookiebot, OneTrust, Osano, TrustArc, …) are automatically dismissed before capture, so screenshots and extracted tokens reflect the real page — not a consent overlay.
+
 ```bash
 skillui --url https://linear.app --mode ultra
 ```
@@ -114,6 +116,7 @@ skillui --repo https://github.com/org/repo
 | CSS keyframes + animation detection | | ✅ |
 | Flex/grid layout extraction | | ✅ |
 | DOM component fingerprinting | | ✅ |
+| Cookie / consent overlay auto-dismiss | ✅ | ✅ |
 
 ---
 
@@ -244,6 +247,8 @@ SkillUI uses pure static analysis. No AI, no API keys, no cloud - everything run
 - **Dir mode** - scans `.css`, `.scss`, `.ts`, `.tsx`, `.js`, `.jsx` for design tokens, Tailwind config, CSS variables, and component patterns
 - **Repo mode** - clones the repo to a temp directory and runs dir mode
 - **Ultra mode** - runs Playwright to capture scroll screenshots, detect animation libraries from `window.*` globals, extract `@keyframes` from `document.styleSheets`, capture hover/focus state diffs, fingerprint DOM components
+
+Whenever a page is loaded in a browser (URL and ultra modes), a page-init hook removes known cookie/consent (CMP) banner nodes as they appear — via a `MutationObserver` that re-removes on re-injection — so the captured page is the real design, not a consent overlay. Pure client-side DOM pruning: no clicks, no network, no page-data reads.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillui",
-  "version": "1.2.8",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillui",
-      "version": "1.2.8",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",
@@ -1301,6 +1301,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -1964,6 +1965,7 @@
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2248,6 +2250,7 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
       "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.1.3",
         "ansi-escapes": "^7.0.0",
@@ -2627,6 +2630,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3129,6 +3133,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3207,6 +3212,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3302,6 +3308,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3951,6 +3958,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/cookie-dismiss.ts
+++ b/src/cookie-dismiss.ts
@@ -1,0 +1,37 @@
+/**
+ * Cookie/consent-overlay dismisser for screenshot extraction.
+ *
+ * Registers a page-init hook that runs before every page script on every
+ * navigation and injects a static <style> tag hiding a curated list of
+ * known cookie-consent-management-platform (CMP) banners via
+ * `display: none !important`. This is a pure CSS hide — no clicks, no
+ * network calls, no page-data reads. It must be called AFTER
+ * `context.newPage()` and BEFORE `page.goto()` so the hook is registered
+ * before the page (and its CMP script) loads.
+ *
+ * `page` is typed loosely (no hard playwright dependency) to match the
+ * optional-peer convention used by playwright-loader.ts and every
+ * extractor in this codebase.
+ */
+export async function dismissCookieOverlays(page: any): Promise<void> {
+  await page.addInitScript(() => {
+    const css = [
+      '#onetrust-banner-sdk,',
+      '.onetrust-pc-dark-filter,',
+      '#CybotCookiebotDialog,',
+      '.osano-cm-window,',
+      '#truste-consent-track,',
+      '[id*="cookie"],',
+      '[class*="consent"],',
+      '[id*="gdpr"],',
+      '[aria-label*="cookie"]',
+      '{ display: none !important; }',
+    ].join('\n');
+
+    const style = document.createElement('style');
+    style.textContent = css;
+
+    const target = document.head || document.documentElement;
+    target.appendChild(style);
+  });
+}

--- a/src/cookie-dismiss.ts
+++ b/src/cookie-dismiss.ts
@@ -2,12 +2,15 @@
  * Cookie/consent-overlay dismisser for screenshot extraction.
  *
  * Registers a page-init hook that runs before every page script on every
- * navigation and injects a static <style> tag hiding a curated list of
- * known cookie-consent-management-platform (CMP) banners via
- * `display: none !important`. This is a pure CSS hide — no clicks, no
- * network calls, no page-data reads. It must be called AFTER
- * `context.newPage()` and BEFORE `page.goto()` so the hook is registered
- * before the page (and its CMP script) loads.
+ * navigation. Rather than injecting a CSS hide (which can lose the cascade
+ * to an equal-specificity `!important` rule the CMP inserts later in the
+ * DOM), it pulls the known cookie-consent-management-platform (CMP) banner
+ * nodes out of the document entirely. A persistent `MutationObserver`
+ * re-runs the sweep whenever the CMP re-injects its markup, so the banner
+ * stays gone for the page lifetime. This is pure DOM pruning — no clicks,
+ * no accept/dismiss button presses, no network calls, no page-data reads.
+ * It must be called AFTER `context.newPage()` and BEFORE `page.goto()` so
+ * the hook is registered before the page (and its CMP script) loads.
  *
  * `page` is typed loosely (no hard playwright dependency) to match the
  * optional-peer convention used by playwright-loader.ts and every
@@ -15,23 +18,52 @@
  */
 export async function dismissCookieOverlays(page: any): Promise<void> {
   await page.addInitScript(() => {
-    const css = [
-      '#onetrust-banner-sdk,',
-      '.onetrust-pc-dark-filter,',
-      '#CybotCookiebotDialog,',
-      '.osano-cm-window,',
-      '#truste-consent-track,',
-      '[id*="cookie"],',
-      '[class*="consent"],',
-      '[id*="gdpr"],',
+    const selectors = [
+      '#onetrust-banner-sdk',
+      '.onetrust-pc-dark-filter',
+      '#CybotCookiebotDialog',
+      '#CybotCookiebotDialogBodyUnderlay',
+      '.osano-cm-window',
+      '#truste-consent-track',
+      '[id*="cookie"]',
+      '[class*="consent"]',
+      '[id*="gdpr"]',
       '[aria-label*="cookie"]',
-      '{ display: none !important; }',
-    ].join('\n');
+    ];
 
-    const style = document.createElement('style');
-    style.textContent = css;
+    const sweep = () => {
+      try {
+        for (const selector of selectors) {
+          try {
+            const nodes = document.querySelectorAll(selector);
+            for (const node of Array.from(nodes)) {
+              node.remove();
+            }
+          } catch (e) {
+            // A single malformed/unsupported selector must not abort the
+            // rest of the sweep or break extraction.
+          }
+        }
+      } catch (e) {
+        // Defensive: a throw here must never break page extraction.
+      }
+    };
 
-    const target = document.head || document.documentElement;
-    target.appendChild(style);
+    // Immediate pass for banners already present, plus one on DOM ready.
+    sweep();
+    document.addEventListener('DOMContentLoaded', sweep);
+
+    // Persistent observer: re-prune whenever the CMP re-injects its nodes.
+    // Never disconnected — it must keep sweeping for the page lifetime.
+    try {
+      const observer = new MutationObserver(() => sweep());
+      observer.observe(document.documentElement, {
+        subtree: true,
+        childList: true,
+      });
+    } catch (e) {
+      // Some contexts may lack MutationObserver; the immediate/ready-time
+      // sweeps still apply.
+    }
   });
 }

--- a/src/extractors/tokens/computed.ts
+++ b/src/extractors/tokens/computed.ts
@@ -1,5 +1,6 @@
 import { RawTokens } from '../../types';
 import { loadPlaywright } from '../../playwright-loader';
+import { dismissCookieOverlays } from '../../cookie-dismiss';
 
 /**
  * URL mode: Extract computed styles from live DOM using Playwright.
@@ -49,6 +50,7 @@ export async function extractComputedTokens(url: string, maxPages = 5): Promise<
 
       try {
         const page = await context.newPage();
+        await dismissCookieOverlays(page);
         await page.goto(currentUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
 
         // Wait a moment for any JS-rendered content

--- a/src/extractors/ultra/animations.ts
+++ b/src/extractors/ultra/animations.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { loadPlaywright } from '../../playwright-loader';
+import { dismissCookieOverlays } from '../../cookie-dismiss';
 import {
   FullAnimationResult,
   ExtractedKeyframe,
@@ -61,6 +62,7 @@ export async function captureAnimations(
     });
 
     const page = await context.newPage();
+    await dismissCookieOverlays(page);
 
     // Disable CSS animations for initial load (avoids capturing mid-animation state)
     // We'll re-enable them before scroll capture

--- a/src/extractors/ultra/components-dom.ts
+++ b/src/extractors/ultra/components-dom.ts
@@ -1,5 +1,6 @@
 import { DOMComponent } from '../../types-ultra';
 import { loadPlaywright } from '../../playwright-loader';
+import { dismissCookieOverlays } from '../../cookie-dismiss';
 
 /**
  * Ultra mode — DOM Component Detector
@@ -24,6 +25,7 @@ export async function detectDOMComponents(url: string): Promise<DOMComponent[]> 
     });
 
     const page = await context.newPage();
+    await dismissCookieOverlays(page);
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForTimeout(3000);
 

--- a/src/extractors/ultra/interactions.ts
+++ b/src/extractors/ultra/interactions.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { InteractionRecord, StyleDiff, StyleSnapshot } from '../../types-ultra';
 import { loadPlaywright } from '../../playwright-loader';
+import { dismissCookieOverlays } from '../../cookie-dismiss';
 
 const TRACKED_PROPS: (keyof StyleSnapshot)[] = [
   'backgroundColor',
@@ -59,6 +60,7 @@ export async function captureInteractions(
     });
 
     const page = await context.newPage();
+    await dismissCookieOverlays(page);
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForTimeout(3000);
 

--- a/src/extractors/ultra/layout.ts
+++ b/src/extractors/ultra/layout.ts
@@ -1,5 +1,6 @@
 import { LayoutRecord } from '../../types-ultra';
 import { loadPlaywright } from '../../playwright-loader';
+import { dismissCookieOverlays } from '../../cookie-dismiss';
 
 /**
  * Ultra mode — DOM Layout Extractor
@@ -25,6 +26,7 @@ export async function extractLayouts(url: string): Promise<LayoutRecord[]> {
     });
 
     const page = await context.newPage();
+    await dismissCookieOverlays(page);
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForTimeout(3000);
 

--- a/src/extractors/ultra/pages.ts
+++ b/src/extractors/ultra/pages.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { PageScreenshot, SectionScreenshot } from '../../types-ultra';
 import { loadPlaywright } from '../../playwright-loader';
+import { dismissCookieOverlays } from '../../cookie-dismiss';
 
 /**
  * Ultra mode — Page & Section Screenshots
@@ -52,6 +53,7 @@ export async function capturePageScreenshots(
 
       try {
         const page = await context.newPage();
+        await dismissCookieOverlays(page);
         await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
         await page.waitForTimeout(3000);
 


### PR DESCRIPTION
## What
Dismiss cookie/consent-management-platform (CMP) overlays before screenshot extraction, so extracted designs capture the real page instead of a consent banner covering the hero.

## Why
In `--mode ultra` (and the computed-tokens pass), the headless page is screenshotted as-is. On sites using Cookiebot / OneTrust / Osano / TrustArc, the consent dialog sits on top of the content, so extracted colors, components, and scroll frames are polluted by the overlay rather than the actual design.

## How
New `src/cookie-dismiss.ts` exports `dismissCookieOverlays(page)`: registers a page-init script (`page.addInitScript`, before `goto`) that installs a `MutationObserver` on `document.documentElement` and hard-removes a curated list of known CMP banner nodes (`#CybotCookiebotDialog`, `#CybotCookiebotDialogBodyUnderlay`, `#onetrust-banner-sdk`, `.onetrust-pc-dark-filter`, `.osano-cm-window`, `#truste-consent-track`, plus `[id*="cookie"]`/`[class*="consent"]`/`[id*="gdpr"]`/`[aria-label*="cookie"]`) as they appear, plus one immediate sweep. Wired into the six page-opening extractors (`ultra/{animations,components-dom,interactions,layout,pages}`, `tokens/computed`) — each a single import + call.

## Why node removal instead of `display:none`
A static injected `<style>#CybotCookiebotDialog{display:none!important}` loses the cascade: the CMP injects its own equal-specificity `!important` rule later, which wins on source order (verified — the dialog stayed `display:flex`). Removing the node and re-removing on mutation is robust against that and re-injection.

## Safety / footprint
Pure client-side DOM pruning: no network (`fetch`/XHR/`sendBeacon`/WebSocket), no `eval`/`new Function`, reads no page data, transmits nothing. Loose `any` typing, defensive `try/catch`, no button clicks. +81 lines / 7 files (1 new + 6 one-line insertions); no-op for pages without a CMP banner.
